### PR TITLE
Match domains by UUID

### DIFF
--- a/virt_backup/groups/pending.py
+++ b/virt_backup/groups/pending.py
@@ -169,7 +169,7 @@ class BackupGroup:
         :returns: a generator of DomBackup matching
         """
         for backup in self.backups:
-            if backup.dom.ID() == dom.ID():
+            if backup.dom.UUID() == dom.UUID():
                 yield backup
 
     def propagate_default_backup_attr(self):


### PR DESCRIPTION
For all non-active domains .ID() returns the same -1.

<!--
    Thank you for your interest in contributing to virt-backup!

    Please note that this project uses black: https://black.readthedocs.io/en/stable/
    Install black via: https://black.readthedocs.io/en/stable/installation_and_usage.html#installation
    Then run from the root of this repository: black virt_backup tests

    WARNING: CI checks for black are enabled, Travis will then fail if there is any format issue.
-->
